### PR TITLE
[fix/#82]-Tab, BtnTab 컴포넌트 수정

### DIFF
--- a/verbly_fe/src/components/Tab/BtnTab.tsx
+++ b/verbly_fe/src/components/Tab/BtnTab.tsx
@@ -1,15 +1,13 @@
-import { useState } from "react";
-
 type BtnTabProps = {
   label: string;
+  isSelected: boolean;
+  onClick: () => void;
 };
 
-export default function BtnTab({ label }: BtnTabProps) {
-  const [isSelected, setIsSelected] = useState(false);
-
+export default function BtnTab({ label, isSelected, onClick }: BtnTabProps) {
   return (
     <div
-      onClick={() => setIsSelected((prev) => !prev)}
+      onClick={onClick}
       className={`inline-flex items-center gap-[4px] px-[12px] py-[8px] rounded-[24px] cursor-pointer ${
         isSelected ? "bg-violet-50 text-white" : "bg-transparent text-gray-6"
       }`}

--- a/verbly_fe/src/components/Tab/BtnTabs.tsx
+++ b/verbly_fe/src/components/Tab/BtnTabs.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import BtnTab from "./BtnTab";
+
+interface BtnTabsProps {
+  btnTabs: string[];
+  defaultIndex?: number;
+  onChange?: (index: number) => void;
+}
+
+export default function BtnTabs({
+  btnTabs,
+  defaultIndex = 0,
+  onChange,
+}: BtnTabsProps) {
+  const [activeIndex, setActiveIndex] = useState(defaultIndex);
+
+  const handleClick = (index: number) => {
+    setActiveIndex(index);
+    onChange?.(index);
+  };
+
+  return (
+    <div className="flex">
+      {btnTabs.map((label, index) => (
+        <BtnTab
+          key={label}
+          label={label}
+          isSelected={activeIndex === index}
+          onClick={() => handleClick(index)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/verbly_fe/src/components/Tab/Tab.tsx
+++ b/verbly_fe/src/components/Tab/Tab.tsx
@@ -1,13 +1,13 @@
-import { useState } from "react";
 interface TabProps {
   label: string /* 컴포넌트 이름 */;
+  isSelected: boolean;
+  onClick: () => void;
 }
-export default function Tab({ label }: TabProps) {
-  const [isSelected, setIsSelected] = useState(false);
+export default function Tab({ label, isSelected, onClick }: TabProps) {
   return (
     <div
-      onClick={() => setIsSelected((prev) => !prev)}
-      className={`flex justify-center items-center px-[60px] py-[12px] w-[169px] h-[48px] border-b-[1px] border-gray-4"${
+      onClick={onClick}
+      className={`flex justify-center items-center px-[60px] py-[12px] w-auto h-[48px] border-b-[1px] border-gray-4"${
         isSelected
           ? "border-violet-50 text-violet-50"
           : "border-gray-4 text-gray-4"

--- a/verbly_fe/src/components/Tab/Tabs.tsx
+++ b/verbly_fe/src/components/Tab/Tabs.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import Tab from "./Tab";
+
+interface TabsProps {
+  tabs: string[];
+  defaultIndex?: number;
+  onChange?: (index: number) => void;
+}
+
+export default function Tabs({ tabs, defaultIndex = 0, onChange }: TabsProps) {
+  const [activeIndex, setActiveIndex] = useState(defaultIndex);
+
+  const handleClick = (index: number) => {
+    setActiveIndex(index);
+    onChange?.(index);
+  };
+
+  return (
+    <div className="flex">
+      {tabs.map((label, index) => (
+        <Tab
+          key={label}
+          label={label}
+          isSelected={activeIndex === index}
+          onClick={() => handleClick(index)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/verbly_fe/src/pages/Home/Home_Korean.tsx
+++ b/verbly_fe/src/pages/Home/Home_Korean.tsx
@@ -2,7 +2,7 @@ import { Badge } from "../../components/Badge/ContentBadge";
 import FollowButton from "../../components/Button/FollowButton";
 import GNB from "../../components/Nav/GNB";
 import SideMenu from "../../components/Nav/SideMenu";
-import Tab from "../../components/Tab/Tab";
+import Tabs from "../../components/Tab/Tabs";
 export default function Home_Korean() {
   return (
     <div className="min-h-screen">
@@ -18,12 +18,12 @@ export default function Home_Korean() {
             <div>
               {/* Tab */}
               <div className="flex mb-[28px] justify-start gap-0">
-                <div>
-                  <Tab label="For You" />
-                </div>
-                <div>
-                  <Tab label="Hot Post" />
-                </div>
+                <Tabs
+                  tabs={["For You", "Hot Posts"]}
+                  onChange={(index) => {
+                    console.log("선택된 탭:", index);
+                  }}
+                />
               </div>
               <div className="flex flex-col gap-[20px]">
                 {/* Post Card */}


### PR DESCRIPTION
## 📸 작업 내용
> 작업한 내용을 두괄식으로 작성해주세요
- 내용

## 🎞️ 주요 코드 설명
<Tabs
                  tabs={["For You", "Hot Posts"]}
                  onChange={(index) => {
                    console.log("선택된 탭:", index);
                  }}
                />
                
props를 통해 tab 라벨과 클릭 시 이벤트 호출 가능하게 변경하였습니다.
Tabs 와 BtnTabs 부모를 만들어 다중선택, 단일 선택이 가능해졌습니다.

## 🖥️ 구현화면
<img width="436" height="71" alt="image" src="https://github.com/user-attachments/assets/5cb63bd5-c674-4385-82b3-56cf5b169d8f" />

## 🔗 연결된 이슈
- Connected: #82 

## 💬 리뷰어가 집중해서 봐야할 점
props 전달되는지 확인해주세요.
