### PR TITLE
[fix/#88] SideMenu_Tab과 GNB 수정

### DIFF
--- a/verbly_fe/src/components/Home/Home_Card.tsx
+++ b/verbly_fe/src/components/Home/Home_Card.tsx
@@ -1,0 +1,47 @@
+import { UserProfile } from "../Profile/Profile";
+
+type HomeCardProps = {
+  isCorrected: boolean;
+};
+
+const MOCK_USER = {
+  id: 1,
+  name: "김철수",
+  profileUrl: "https://via.placeholder.com/150",
+  introduction: "안녕하세요! 프론트엔드 개발자입니다.",
+  lastActive: "방금 전",
+  level: 12,
+  badges: "Expert", // Badge 컴포넌트 타입에 맞춰 수정 필요
+};
+
+export default function Home_Card() {
+  return (
+    <div className="flex flex-col bg-white w-[1072px] my-auto p-[24px] border-[1px] border-line1 rounded-[20px] gap-[12px]">
+      {/* Profile */}
+      <UserProfile data={MOCK_USER} size="medium" />
+      {/* Content */}
+      <div>
+        I worked all day and when I came home, I didn’t want to do anything. Is
+        this sentence natural? I worked all day and when I came home, I didn’t
+        want to do anything. Is this sentence natural?
+      </div>
+      {/* Tags */}
+      <div className="flex flex-row gap-[10px] text-blue-60">
+        <div>#Grammer</div>
+        <div>Daily</div>
+        <div>#English</div>
+      </div>
+      {/* Like&Comment */}
+      <div className="border-t-[1px] border-line2 py-[12px] gap-[12px] flex flex-row text-blue-60">
+        <div className="flex flex-row gap-[4px]">
+          <img src="../../src/assets/emoji/heart-false.svg" />
+          <div>12</div>
+        </div>
+        <div className="flex flex-row gap-[4px]">
+          <img src="../../src/assets/emoji/message1.svg" />
+          <div>12</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/verbly_fe/src/components/Logo/Logo.tsx
+++ b/verbly_fe/src/components/Logo/Logo.tsx
@@ -1,16 +1,6 @@
-/*
-  svg 사용이 안되어 오류 발생합니다.
-  //@ts-ignore 는 타입 무시입니다.
-  임시방편이니 해결되면 지우고 사용하면 됩니다.
-*/
-
-//@ts-ignore
 import logoSmall from "./img/logo-small.svg";
-//@ts-ignore
 import logoLarge from "./img/logo-large.svg";
-//@ts-ignore
 import logoHori from "./img/logo-hori.svg";
-//@ts-ignore
 import logoVerti from "./img/logo-verti.svg";
 
 export default function Logo({ variant = "small" }) {

--- a/verbly_fe/src/components/Nav/GNB.tsx
+++ b/verbly_fe/src/components/Nav/GNB.tsx
@@ -1,5 +1,4 @@
 import Logo from "../Logo/Logo";
-import SearchIcon from "../../assets/emoji/search-gray.svg";
 import { SearchBar } from "../SearchBar/SearchBar";
 
 export default function GNB({ variant = "default" }) {

--- a/verbly_fe/src/components/Nav/GNB.tsx
+++ b/verbly_fe/src/components/Nav/GNB.tsx
@@ -1,5 +1,6 @@
 import Logo from "../Logo/Logo";
 import SearchIcon from "../../assets/emoji/search-gray.svg";
+import { SearchBar } from "../SearchBar/SearchBar";
 
 export default function GNB({ variant = "default" }) {
   const isActive = true;
@@ -32,16 +33,10 @@ export default function GNB({ variant = "default" }) {
       return (
         <div className="flex items-center justify-between w-full h-[60px] bg-white px-[40px] py-[8px]">
           <Logo variant="hori" />
-          <div className="flex w-[680px] h-[40px] px-[20px] py-[8px] bg-bg1 rounded-[20px] border-[1px] border-line1">
-            <img
-              src={SearchIcon}
-              className="mr-[12px] w-[24px] h-[24px] fill-gray-4"
-            />
-            <input
-              placeholder="Search topcis, users or keywords,,,"
-              className="w-[604px] text-[16px] truncate focus:outline-none placeholder-gray-4"
-            ></input>
-          </div>
+          <SearchBar
+            shape="round"
+            placeholder="Search topcis, users or keywords,,,"
+          />
           <div
             className={`relative w-[44px] h-[44px] rounded-[24px] px-[3px] py-[3px] flex items-center justify-center ${
               isActive ? "bg-violet-90" : ""

--- a/verbly_fe/src/components/Nav/SideMenu_Tab.tsx
+++ b/verbly_fe/src/components/Nav/SideMenu_Tab.tsx
@@ -5,7 +5,7 @@ type SideMenuProps = {
 };
 export default function SideMenu_Tab({
   label,
-  isSelected,
+  isSelected = false,
   onClick,
 }: SideMenuProps) {
   return (

--- a/verbly_fe/src/components/Nav/SideMenu_Tab.tsx
+++ b/verbly_fe/src/components/Nav/SideMenu_Tab.tsx
@@ -1,8 +1,17 @@
-export default function SideMenu_Tab() {
-  const isSelected = true;
+type SideMenuProps = {
+  label: string;
+  isSelected: boolean;
+  onClick: () => void;
+};
+export default function SideMenu_Tab({
+  label,
+  isSelected,
+  onClick,
+}: SideMenuProps) {
   return (
     <div
-      className={`w-[172px] h-[56px] flex items-center gap-[20px] px-[16px] rounded-[4px] text-[20px] ${
+      onClick={onClick}
+      className={`w-[172px] h-[56px] flex items-center gap-[20px] px-[16px] rounded-[4px] text-[20px] cursor-pointer ${
         isSelected
           ? "bg-violet-100 text-violet-50 border-[1px] border-violet-50"
           : "bg-white"
@@ -16,7 +25,7 @@ export default function SideMenu_Tab() {
         }`}
         className="w-[20px] h-[20px]"
       />
-      <span>Text</span>
+      <span>{label}</span>
     </div>
   );
 }

--- a/verbly_fe/src/pages/Home/Home_Korean.tsx
+++ b/verbly_fe/src/pages/Home/Home_Korean.tsx
@@ -2,6 +2,7 @@ import { Badge } from "../../components/Badge/ContentBadge";
 import FollowButton from "../../components/Button/FollowButton";
 import GNB from "../../components/Nav/GNB";
 import SideMenu from "../../components/Nav/SideMenu";
+import SideMenu_Tab from "../../components/Nav/SideMenu_Tab";
 import Tabs from "../../components/Tab/Tabs";
 import TrendingTag from "../../components/TrendingTag/TrendingTag";
 export default function Home_Korean() {
@@ -26,6 +27,11 @@ export default function Home_Korean() {
                   }}
                 />
               </div>
+              <SideMenu_Tab
+                label="hi"
+                isSelected={true}
+                onClick={() => console.log("hi")}
+              />
               <div className="flex flex-col gap-[20px]">
                 {/* Post Card */}
                 <div className="flex flex-col bg-white w-[1072px] my-auto p-[24px] border-[1px] border-line1 rounded-[20px] gap-[12px]">

--- a/verbly_fe/src/pages/Home/Home_Korean.tsx
+++ b/verbly_fe/src/pages/Home/Home_Korean.tsx
@@ -1,8 +1,8 @@
 import { Badge } from "../../components/Badge/ContentBadge";
 import FollowButton from "../../components/Button/FollowButton";
+import Home_Card from "../../components/Home/Home_Card";
 import GNB from "../../components/Nav/GNB";
 import SideMenu from "../../components/Nav/SideMenu";
-import SideMenu_Tab from "../../components/Nav/SideMenu_Tab";
 import Tabs from "../../components/Tab/Tabs";
 import TrendingTag from "../../components/TrendingTag/TrendingTag";
 export default function Home_Korean() {
@@ -20,55 +20,10 @@ export default function Home_Korean() {
             <div>
               {/* Tab */}
               <div className="flex mb-[28px] justify-start gap-0">
-                <Tabs
-                  tabs={["For You", "Hot Posts"]}
-                  onChange={(index) => {
-                    console.log("선택된 탭:", index);
-                  }}
-                />
+                <Tabs tabs={["For You", "Hot Posts"]} />
               </div>
-              <SideMenu_Tab
-                label="hi"
-                isSelected={true}
-                onClick={() => console.log("hi")}
-              />
               <div className="flex flex-col gap-[20px]">
-                {/* Post Card */}
-                <div className="flex flex-col bg-white w-[1072px] my-auto p-[24px] border-[1px] border-line1 rounded-[20px] gap-[12px]">
-                  {/* Profile */}
-                  <div className="bg-white flex flex-row  gap-[12px] items-center">
-                    <div className="w-[48px] h-[48px] bg-gray-3 rounded-[50px]"></div>
-                    <div className="flex flex-col gap-[4px]">
-                      <div className="text-gray-10 text-[20px]">Mark</div>
-                      <div className="text-gray-5 text-[14px]">10min</div>
-                    </div>
-                    <FollowButton />
-                  </div>
-                  {/* Content */}
-                  <div>
-                    I worked all day and when I came home, I didn’t want to do
-                    anything. Is this sentence natural? I worked all day and
-                    when I came home, I didn’t want to do anything. Is this
-                    sentence natural?
-                  </div>
-                  {/* Tags */}
-                  <div className="flex flex-row gap-[10px] text-blue-60">
-                    <div>#Grammer</div>
-                    <div>Daily</div>
-                    <div>#English</div>
-                  </div>
-                  {/* Like&Comment */}
-                  <div className="border-t-[1px] border-line2 py-[12px] gap-[12px] flex flex-row text-blue-60">
-                    <div className="flex flex-row gap-[4px]">
-                      <img src="../../src/assets/emoji/heart-false.svg" />
-                      <div>12</div>
-                    </div>
-                    <div className="flex flex-row gap-[4px]">
-                      <img src="../../src/assets/emoji/message1.svg" />
-                      <div>12</div>
-                    </div>
-                  </div>
-                </div>
+                <Home_Card />
 
                 {/* Post Card */}
                 <div className="flex flex-col bg-white w-[1072px] my-auto p-[24px] border-[1px] border-line1 rounded-[20px] gap-[12px]">


### PR DESCRIPTION
## 📸 작업 내용
- SideMemu_Tab prop을 통한 상태관리 가능해짐
- GNB에서 searchBar 컴포넌트를 사용하도록 함

## 🖥️ 구현화면
<img width="163" height="66" alt="image" src="https://github.com/user-attachments/assets/9cd3f541-14e9-479f-8449-16c1cd8cb174" />
<img width="613" height="59" alt="image" src="https://github.com/user-attachments/assets/a5b93a8f-d023-4b89-a865-b2180acb0220" />


## 🔗 연결된 이슈
- Connected: #88

## 💬 리뷰어가 집중해서 봐야할 점
원하시는 방향으로 수정되었는지 확인 부탁드립니다.
