### PR TITLE
[refactor/#102] BtnTabs 아이콘 삽입 기능 추가

### DIFF
--- a/verbly_fe/src/components/Tab/BtnTab.tsx
+++ b/verbly_fe/src/components/Tab/BtnTab.tsx
@@ -1,10 +1,16 @@
 type BtnTabProps = {
   label: string;
+  iconSrc: string;
   isSelected: boolean;
   onClick: () => void;
 };
 
-export default function BtnTab({ label, isSelected, onClick }: BtnTabProps) {
+export default function BtnTab({
+  label,
+  iconSrc,
+  isSelected,
+  onClick,
+}: BtnTabProps) {
   return (
     <div
       onClick={onClick}
@@ -12,14 +18,7 @@ export default function BtnTab({ label, isSelected, onClick }: BtnTabProps) {
         isSelected ? "bg-violet-50 text-white" : "bg-transparent text-gray-6"
       }`}
     >
-      <img
-        src={
-          isSelected
-            ? "../../src/assets/emoji/checkbox-dashed-white.svg"
-            : "../../src/assets/emoji/checkbox-dashed-gray.svg"
-        }
-        className="w-[24px] h-[24px]"
-      />
+      <img src={iconSrc} className="w-[24px] h-[24px]" />
       <span>{label}</span>
     </div>
   );

--- a/verbly_fe/src/components/Tab/BtnTabs.tsx
+++ b/verbly_fe/src/components/Tab/BtnTabs.tsx
@@ -3,12 +3,14 @@ import BtnTab from "./BtnTab";
 
 interface BtnTabsProps {
   btnTabs: string[];
+  iconSrcs: string[];
   defaultIndex?: number;
   onChange?: (index: number) => void;
 }
 
 export default function BtnTabs({
   btnTabs,
+  iconSrcs,
   defaultIndex = 0,
   onChange,
 }: BtnTabsProps) {
@@ -20,11 +22,12 @@ export default function BtnTabs({
   };
 
   return (
-    <div className="flex">
+    <div className="flex inline-flex bg-gray-2 p-[4px] rounded-[24px]">
       {btnTabs.map((label, index) => (
         <BtnTab
           key={label}
           label={label}
+          iconSrc={iconSrcs[index] ?? ""}
           isSelected={activeIndex === index}
           onClick={() => handleClick(index)}
         />


### PR DESCRIPTION
## 📸 작업 내용
- BtnTabs 컴포넌트의 tab 각각에 아이콘을 삽입할 수 있는 기능을 추가했습니다.

## 🎞️ 주요 코드 설명
import arrowback from "../../assets/emoji/arrow-back.svg";
import arrowfront from "../../assets/emoji/arrow-front.svg";
(...)
<BtnTabs
    btnTabs={["Write", "Correction"]}
    iconSrcs={[arrowback, arrowfront]}
              />

## 🖥️ 구현화면
<img width="276" height="79" alt="image" src="https://github.com/user-attachments/assets/2480a722-fbee-494d-8093-46a685446fb6" />

## 🔗 연결된 이슈
- Connected: #102 

## 💬 리뷰어가 집중해서 봐야할 점
BtnTabs의 부모 컴포넌트에 따라 길이가 변경되는 지 확인해주세요.
해당 이슈로 불편 발생 시 재조정 요청해 주세요!
