### PR TITLE
[style/#145] Nav,Tab 컴포넌트와 Home 페이지 "텍스트" 반응형으로 수정

### DIFF
--- a/src/components/Home/Home_Card.tsx
+++ b/src/components/Home/Home_Card.tsx
@@ -38,7 +38,7 @@ export default function Home_Card({
       const data = await getComments(post.postId, pageNumber);
 
       setComments((prev) =>
-        pageNumber === 0 ? data.content : [...prev, ...data.content]
+        pageNumber === 0 ? data.content : [...prev, ...data.content],
       );
 
       setCommentLast(data.last);
@@ -81,21 +81,25 @@ export default function Home_Card({
           <div className="border-t-[1px] border-line2 py-[12px] gap-[12px] flex flex-row text-blue-60">
             <div className="flex flex-row gap-[4px]">
               <img src={HeartIcon} />
-              <div>{post.likesCount}</div>
+              <div className="text-[length:var(--fs-subtitle2)]">
+                {post.likesCount}
+              </div>
             </div>
             <div
               onClick={() => setIsCommentOpen((prev) => !prev)}
               className="flex flex-row gap-[4px]"
             >
               <img src={CommentIcon} />
-              <div>{post.commentsCount}</div>
+              <div className="text-[length:var(--fs-subtitle2)]">
+                {post.commentsCount}
+              </div>
             </div>
           </div>
 
           {isCommentOpen && (
             <>
               <div className="w-full h-auto px-[12px] py-[24px] rounded-[8px] flex flex-col gap-[12px] bg-bg0">
-                <div className="flex flex-row text-blue-60 text-[16px] gap-[4px] font-medium">
+                <div className="flex flex-row text-blue-60 text-[length:var(--fs-subtitle2)] gap-[4px] font-medium">
                   <img
                     src="../../src/assets/emoji/message1.svg"
                     className="w-[20px] h-[20px]"

--- a/src/components/Home/Home_WriteModal.tsx
+++ b/src/components/Home/Home_WriteModal.tsx
@@ -62,7 +62,7 @@ export default function Home_WriteModal({
         {/* Settings */}
         <div className="flex flex-col gap-[20px] w-full">
           <div className="flex flex-col gap-[4px] w-full">
-            <div className="text-violet-20 font-semibold text-[16px] leading-[24px]">
+            <div className="text-violet-20 font-semibold text-[length:var(--fs-subtitle2)] leading-[24px]">
               Public Setting
             </div>
             <Select
@@ -75,10 +75,10 @@ export default function Home_WriteModal({
           {/* 한국인의 경우에만 렌더링 */}
           {variant === "KOREAN" && (
             <div className="w-full p-[8px] flex flex-col gap-[5px] bg-violet-100 rounded-[8px]">
-              <div className="text-violet-20 font-semibold text-[16px] leading-[24px]">
+              <div className="text-violet-20 font-semibold text-[length:var(--fs-subtitle2)] leading-[24px]">
                 Help Needed
               </div>
-              <div className="text-violet-20 font-normal text-[12px]">
+              <div className="text-violet-20 font-normal text-[length:var(--fs-button2)]">
                 원어민의 Need correction 피드에 노출되어 빠른 교정을 받을 수
                 있습니다.
               </div>
@@ -92,7 +92,7 @@ export default function Home_WriteModal({
 
           {/* Chip (Tags) */}
           <div className="flex flex-col gap-[4px]">
-            <div className="text-violet-20 font-semibold text-[16px] leading-[24px]">
+            <div className="text-violet-20 font-semibold text-[length:var(--fs-subtitle2)] leading-[24px]">
               Tag
             </div>
             <Home_ChipBox tags={tags} setTags={setTags} />

--- a/src/components/Nav/SideMenu_Tab.tsx
+++ b/src/components/Nav/SideMenu_Tab.tsx
@@ -14,7 +14,7 @@ export default function SideMenu_Tab({
   return (
     <div
       {...props}
-      className={`w-[172px] h-[56px] flex items-center gap-[20px] px-[16px] rounded-[4px] text-[20px] cursor-pointer ${
+      className={`w-[172px] h-[56px] flex items-center gap-[20px] px-[16px] rounded-[4px] text-[length:var(--fs-title3)] cursor-pointer ${
         isSelected
           ? "bg-violet-100 text-violet-50 border-[1px] border-violet-50"
           : "bg-white"

--- a/src/components/Nav/components/Alarm.tsx
+++ b/src/components/Nav/components/Alarm.tsx
@@ -3,8 +3,12 @@ export default function Alarm() {
     <div className="flex flex-row items-center gap-[8px] w-[369px] h-[63px] px-[8px] py-[12px] border-b-[1px] border-gray-1 bg-violet-110 cursor-pointer">
       <div className="w-[8px] h-[8px] bg-violet-50 rounded-[50px]" />
       <div className="flex flex-col justify-center">
-        <div className="text-[16px]">Jisu liked your post.</div>
-        <div className="text-[14px] text-gray-5 font-medium">5m ago</div>
+        <div className="text-[length:var(--fs-subtitle2)]">
+          Jisu liked your post.
+        </div>
+        <div className="text-[length:var(--fs-body2)] text-gray-5 font-medium">
+          5m ago
+        </div>
       </div>
     </div>
   );

--- a/src/components/Tab/BtnTab.tsx
+++ b/src/components/Tab/BtnTab.tsx
@@ -14,7 +14,7 @@ export default function BtnTab({
   return (
     <div
       onClick={onClick}
-      className={`inline-flex items-center gap-[4px] px-[12px] py-[8px] rounded-[24px] cursor-pointer ${
+      className={`inline-flex items-center gap-[4px] px-[12px] py-[8px] rounded-[24px] text-[length:var(--fs-subtitle2)] cursor-pointer ${
         isSelected ? "bg-violet-50 text-white" : "bg-transparent text-gray-6"
       }`}
     >

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -7,7 +7,7 @@ export default function Tab({ label, isSelected, onClick }: TabProps) {
   return (
     <div
       onClick={onClick}
-      className={`flex justify-center items-center px-[60px] py-[12px] w-auto h-[48px] text-[24px] font-semibold ${isSelected ? "border-violet-50 border-b-[2px] text-violet-50" : "text-gray-4"}`}
+      className={`flex justify-center items-center px-[60px] py-[12px] w-auto h-[48px] text-[length:var(--fs-title1)] font-semibold ${isSelected ? "border-violet-50 border-b-[2px] text-violet-50" : "text-gray-4"}`}
     >
       <div>{label}</div>
     </div>

--- a/src/pages/Home/Home_Notification.tsx
+++ b/src/pages/Home/Home_Notification.tsx
@@ -21,7 +21,7 @@ export default function Home_Notification() {
                   src="../../src/assets/emoji/check-purple.svg"
                   className="w-[24px] h-[24px]"
                 />
-                <div className="font-semibold text-violet-50 text-[18px]">
+                <div className="font-semibold text-violet-50 text-[length:var(--fs-subtitle1)]">
                   Mark All read
                 </div>
               </div>
@@ -33,8 +33,10 @@ export default function Home_Notification() {
                   <div className="flex flex-row gap-[20px]">
                     <div className="w-[85px] h-[85px] rounded-[171px] bg-gray-10" />
                     <div className="flex flex-col gap-[3px] py-[18px]">
-                      <div className="text-[22px] font-semibold">Contents</div>
-                      <div className="text-[16px] font-normal leading-[24px] text-gray-5">
+                      <div className="text-[length:var(--fs-title2)] font-semibold">
+                        Contents
+                      </div>
+                      <div className="text-[length:var(--fs-subtitle2)] font-normal leading-[24px] text-gray-5">
                         10min
                       </div>
                     </div>
@@ -57,8 +59,10 @@ export default function Home_Notification() {
                   <div className="flex flex-row gap-[20px]">
                     <div className="w-[85px] h-[85px] rounded-[171px] bg-gray-10" />
                     <div className="flex flex-col gap-[3px] py-[18px]">
-                      <div className="text-[22px] font-semibold">Contents</div>
-                      <div className="text-[16px] font-normal leading-[24px] text-gray-5">
+                      <div className="text-[length:var(--fs-title1)] font-semibold">
+                        Contents
+                      </div>
+                      <div className="text-[length:var(--fs-subtitle2)] font-normal leading-[24px] text-gray-5">
                         10min
                       </div>
                     </div>

--- a/src/pages/Home/Home_Profile.tsx
+++ b/src/pages/Home/Home_Profile.tsx
@@ -88,43 +88,43 @@ export default function Home_Profile() {
                         className="w-[48px] h-[48px] p-[3.33px]"
                       />
                     </div>
-                    <div className="text-[18px] text-gray-7 font-semibold">
+                    <div className="text-[length:var(--fs-subtitle1)] text-gray-7 font-semibold">
                       {Uuser?.nativeLang === "ko" ? "Korean" : "English"}
                     </div>
                   </div>
-                  <div className="w-[700px] h-auto text-[16px] leading-[24px]">
+                  <div className="w-[700px] h-auto text-[length:var(--fs-subtitle2)] leading-[24px]">
                     {Uuser?.description}
                   </div>
                   <div className="flex gap-[16px]">
                     <div className="flex gap-[4px] items-center">
-                      <span className="text-[18px] font-semibold">
+                      <span className="text-[length:var(--fs-subtitle1)] font-semibold">
                         {Uuser?.totalPosts}
                       </span>
-                      <span className="text-[16px] leading-[24px] text-gray-6">
+                      <span className="text-[length:var(--fs-subtitle2)] leading-[24px] text-gray-6">
                         Posts
                       </span>
                     </div>
                     <div className="flex gap-[4px] items-center">
-                      <span className="text-[18px] font-semibold">
+                      <span className="text-[length:var(--fs-subtitle1)] font-semibold">
                         {Uuser?.follower}
                       </span>
-                      <span className="text-[16px] leading-[24px] text-gray-6">
+                      <span className="text-[length:var(--fs-subtitle2)] leading-[24px] text-gray-6">
                         Follower
                       </span>
                     </div>
                     <div className="flex gap-[4px] items-center">
-                      <span className="text-[18px] font-semibold">
+                      <span className="text-[length:var(--fs-subtitle1)] font-semibold">
                         {Uuser?.following}
                       </span>
-                      <span className="text-[16px] leading-[24px] text-gray-6">
+                      <span className="text-[length:var(--fs-subtitle2)] leading-[24px] text-gray-6">
                         Follow
                       </span>
                     </div>
                     <div className="flex gap-[4px] items-center">
-                      <span className="text-[18px] font-semibold">
+                      <span className="text-[length:var(--fs-subtitle1)] font-semibold">
                         {Uuser?.correctionGiven}
                       </span>
-                      <span className="text-[16px] leading-[24px] text-gray-6">
+                      <span className="text-[length:var(--fs-subtitle2)] leading-[24px] text-gray-6">
                         Given Correct
                       </span>
                     </div>

--- a/src/pages/Home/Home_Search.tsx
+++ b/src/pages/Home/Home_Search.tsx
@@ -35,7 +35,7 @@ export default function Home_Search() {
               <span className="font-bold text-[40px] text-blue-60">
                 Korean Culture
               </span>
-              <span className="text-[24px] font-semibold text-[24px]">
+              <span className="text-[length:var(--fs-title1)] font-semibold">
                 에 대한 결과입니다.
               </span>
             </div>

--- a/src/pages/Home/components/UserStatsCard.tsx
+++ b/src/pages/Home/components/UserStatsCard.tsx
@@ -34,7 +34,7 @@ export const UserStatsCard: React.FC<UserStatsCardProps> = ({
   return (
     <div className="bg-white p-[20px] rounded-[12px] border border-line1 flex flex-col items-center gap-[12px] shadow-sm">
       {/* UserProfile - 180px 크기 */}
-      <div className="[&_img]:!w-[180px] [&_img]:!h-[180px] [&_h2]:!text-[24px] [&_span]:!text-[16px]">
+      <div className="[&_img]:!w-[180px] [&_img]:!h-[180px] [&_h2]:!text-[length:var(--fs-title1)] [&_span]:!text-[length:var(--fs-subtitle2)]">
         <UserProfile size="large" data={displayUser} />
       </div>
 

--- a/src/pages/Home/types.ts
+++ b/src/pages/Home/types.ts
@@ -17,13 +17,13 @@ export interface QuizSession {
 export interface QuizQuestion {
   id: string;
   questionId: string;
-  type: 'FILL_IN_BLANK' | 'MULTIPLE_CHOICE' | 'SHORT_ANSWER';
+  type: "FILL_IN_BLANK" | "MULTIPLE_CHOICE" | "SHORT_ANSWER";
   sentence: string;
   answer: string;
   options?: QuizOption[];
   highlighted: {
     text: string;
-    position: 'start' | 'middle' | 'end';
+    position: "start" | "middle" | "end";
   };
 }
 
@@ -97,7 +97,7 @@ export interface DailyReviewStats {
 /**
  * 퀴즈 진행 상태
  */
-export type QuizStatus = 'idle' | 'in-progress' | 'completed' | 'quit';
+export type QuizStatus = "idle" | "in-progress" | "completed" | "quit";
 
 /**
  * 퀴즈 세션 상태 (프론트엔드 상태 관리용)


### PR DESCRIPTION
## 📸 작업 내용
- 40px를 제외한 폰트의 length를 rem 기준으로 수정하였습니다.

## 🖥️ 구현화면
>이전과 같이 작동합니다.

## 🔗 연결된 이슈
> 해결한 이슈 번호를 작성!
- Connected: #145 

## 💬 리뷰어가 집중해서 봐야할 점
텍스트가 깨지는 부분이 있나 확인 부탁드려요.
