### PR TITLE
[fix/#135] 프로필에 유저 정보가 넘어가지 않는 오류 해결

### DIFF
--- a/src/components/Home/Home_Card.tsx
+++ b/src/components/Home/Home_Card.tsx
@@ -32,6 +32,8 @@ export default function Home_Card({
   const navigate = useNavigate();
 
   const [isCommentOpen, setIsCommentOpen] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+
   const [comments, setComments] = useState<CommentItemType[]>([]);
   const [commentInput, setCommentInput] = useState("");
   const [commentPage, setCommentPage] = useState(0);
@@ -140,7 +142,21 @@ export default function Home_Card({
             )}
           </div>
           {/* Content */}
-          <div>{post.content}</div>
+          <div>
+            <div
+              className={`text-[length:var(--fs-subtitle2)] ${isExpanded ? "" : "line-clamp-3"}`}
+            >
+              {post.content}
+            </div>
+            {post.content.length > 120 && (
+              <span
+                onClick={() => setIsExpanded((prev) => !prev)}
+                className="text-gray-6 text-[length:var(--fs-subtitle2)] cursor-pointer"
+              >
+                {isExpanded ? "접기" : "더보기"}
+              </span>
+            )}
+          </div>
           {/* Tags */}
           <div className="flex flex-row gap-[10px] text-blue-60">
             {post.tags.map((tag) => (

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -48,7 +48,12 @@ export const UserProfile: React.FC<ProfileProps> = ({
 
   // ID 추출 (없으면 undefined)
   const rawId = data.userId ?? data.id ?? data.writerId;
-  const targetUserId = rawId ? String(rawId) : undefined;
+
+  //유진: 두개의 타입이 필요해서 수정했습니다.
+  //const targetUserId = rawId ?? undefined; <-- 원래 이거 였음
+  const numericUserId = typeof rawId === "number" ? rawId : undefined;
+
+  const uuidUserId = typeof rawId === "string" ? rawId : undefined;
 
   const displayName = data.nickname || data.name || "User";
   const displayImage = data.profileImage || data.profileImg;
@@ -68,8 +73,8 @@ export const UserProfile: React.FC<ProfileProps> = ({
 
   const handleMoveToProfile = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!targetUserId) return;
-    navigate(`/home/profile/${targetUserId}`);
+    if (!uuidUserId) return;
+    navigate(`/home/profile/${uuidUserId}`);
   };
 
   const renderImage = () => (
@@ -127,8 +132,8 @@ export const UserProfile: React.FC<ProfileProps> = ({
         </div>
 
         <FollowButton
-          key={targetUserId}
-          userId={targetUserId}
+          key={numericUserId}
+          userId={numericUserId}
           initialIsFollowing={data.isFollowing}
           onToggle={onFollow}
         />

--- a/src/pages/Home/Home_Profile.tsx
+++ b/src/pages/Home/Home_Profile.tsx
@@ -78,7 +78,7 @@ export default function Home_Profile() {
                 {/* Profile */}
                 <div className="w-full p-[20px] flex flex-row gap-[52px]">
                   <img
-                    src={Uuser?.imageUrl ?? ""}
+                    src={Uuser?.imageUrl || undefined}
                     alt="profile"
                     className="size-[180px] rounded-full"
                   />
@@ -147,7 +147,10 @@ export default function Home_Profile() {
                   </div>
                 </div>
                 {/* Tabs */}
-                <Tabs tabs={["Posts"]} />
+                <div className="flex mb-[28px] justify-start gap-0 border-b-[1px] border-line2">
+                  <Tabs tabs={["Posts"]} />
+                </div>
+
                 <section className="p-[28px] flex flex-col gap-[20px]">
                   {posts.map((post) => (
                     <Home_Card


### PR DESCRIPTION
## 📸 작업 내용
> 작업한 내용을 두괄식으로 작성해주세요
- 프로필 화면으로 유저 정보가 넘어가지 않는 현상을 해결했습니다.
- 긴 텍스트에 대해 더보기 기능을 추가했습니다.

## 🖥️ 구현화면
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/5ff1e8a0-abd8-48a5-a19d-6795c2bfe460" />

## 🔗 연결된 이슈
> 해결한 이슈 번호를 작성!
- Connected: #135 

## 💬 리뷰어가 집중해서 봐야할 점
<!-- 다른 로컬로 돌렸을 때 확인하고 싶은 점, 스타일 등 -->
글을 작성하고 본인의 프로필이 맞게 뜨는지 확인부탁드려요.
